### PR TITLE
Implement `get_fileid()`

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -11,7 +11,7 @@ int parser_translate(const char* vmfile, FILE* fp_out) {
     char  line[128];
     
     // get unique file id for statics
-    char* file_id = rfind(vmfile, '/');
+    char* file_id = get_fileid(vmfile);
 
     // open file
     fp_in = fopen(vmfile, "r");
@@ -33,8 +33,9 @@ int parser_translate(const char* vmfile, FILE* fp_out) {
         write_comment(line, fp_out);
 
         // parse line
-        if (parse_line(line, file_id + 1, fp_out) != 0) { // TODO fix hackiness with file_id
+        if (parse_line(line, file_id, fp_out) != 0) { 
             printf("Error parsing line `%s` from file `%s`\n", line, vmfile);
+            free(file_id);
             fclose(fp_in);
             return 1;
         }
@@ -42,6 +43,9 @@ int parser_translate(const char* vmfile, FILE* fp_out) {
      
     // close file
     fclose(fp_in);
+
+    // free file_id
+    free(file_id);
 
     return 0;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,6 +6,7 @@
 //              target : target char
 // Returns:     Pointer to last location in `s` of `target`
 char* rfind(char* s, char target) {
+    // TODO: if `target` not found, does this return NULL? or s?
     char *p = 0;
 
     while (target != 0 && s != 0 && *s != '\0') {
@@ -41,4 +42,16 @@ int mystrcmp(const char* s1, const char* s2) {
     }
 
     return 0;
+}
+
+char* fileid(const char* filepath) {
+    // TODO: if rfind returns NULL when not found, then handle that
+    char* filename;
+    char* p;
+
+    filename = rfind(filepath, '/');
+    p = rfind(filename, '.');
+    *p = 0;
+
+    return filename;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,3 +1,5 @@
+#include "utils.h"
+
 // Function:    rfind
 // Description: Home-rolled version of strrchr(). Searches for last
 //              occurrence of `target` in string `s` and returns a
@@ -5,16 +7,19 @@
 // Arguments:   s      : input string
 //              target : target char
 // Returns:     Pointer to last location in `s` of `target`
-char* rfind(char* s, char target) {
-    // TODO: if `target` not found, does this return NULL? or s?
-    char *p = 0;
+char* rfind(const char* s, char target) {
+    if (s == NULL) {
+        return NULL;
+    }
 
-    while (target != 0 && s != 0 && *s != '\0') {
-        if (*s == target) { p = s; }
+    char *last_occurrence = NULL;
+
+    while (*s != '\0') {
+        if (*s == target) { last_occurrence = (char *)s; }
         s++;
     }
 
-    return p;
+    return last_occurrence;
 }
 
 // Function:    mystrcmp
@@ -44,14 +49,32 @@ int mystrcmp(const char* s1, const char* s2) {
     return 0;
 }
 
-char* fileid(const char* filepath) {
-    // TODO: if rfind returns NULL when not found, then handle that
-    char* filename;
-    char* p;
+// Function:    get_fileid
+// Description: Extracts filename (excluding extension) from path. Function
+//              dynamically allocates memory for output string; caller responsible
+//              for freeing returned char*.
+// Arguments:   filepath : filename, e.g. path/to/myfile.ext
+// Returns:     Pointer to dynamically-allocated fileid string 
+char* get_fileid(const char* filepath) {
+    if (filepath == NULL) {
+        return NULL;
+    }
 
-    filename = rfind(filepath, '/');
-    p = rfind(filename, '.');
-    *p = 0;
+    char* last_slash = rfind(filepath, '/');
 
-    return filename;
+    if (last_slash) {
+        last_slash++;
+    } else {
+        last_slash = (char *)filepath;
+    }
+
+    char *last_dot = rfind(last_slash, '.');
+
+    size_t len = last_dot ? (size_t)(last_dot - last_slash) : strlen(last_slash);
+
+    char* result = (char *)malloc(len + 1);
+    strncpy(result, last_slash, len);
+    result[len] = '\0';
+
+    return result;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,8 +1,11 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-char* rfind(char* s, char target);
+#include <string.h>
+#include <stdlib.h>
+
+char* rfind(const char* s, char target);
 int   mystrcmp(const char* s1, const char* s2);
-char* fileid(const char* filepath);
+char* get_fileid(const char* filepath);
 
 #endif // UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,5 +3,6 @@
 
 char* rfind(char* s, char target);
 int   mystrcmp(const char* s1, const char* s2);
+char* fileid(const char* filepath);
 
 #endif // UTILS_H

--- a/src/writer.c
+++ b/src/writer.c
@@ -371,7 +371,7 @@ int write_return(FILE *fp) {
     fputs("M=D\n", fp); 
 
     // ARG = *(FRAME-3)
-    fputs("@FRAME\n\n", fp);
+    fputs("@FRAME\n", fp);
     fputs("D=M\n", fp);
     fputs("@3\n", fp);
     fputs("A=D-A\n", fp);
@@ -380,12 +380,12 @@ int write_return(FILE *fp) {
     fputs("M=D\n", fp); 
     
     // LCL = *(FRAME-4)
-    fputs("@FRAME\n\n", fp);
+    fputs("@FRAME\n", fp);
     fputs("D=M\n", fp);
     fputs("@4\n", fp);
     fputs("A=D-A\n", fp);
     fputs("D=M\n", fp);
-    fputs("@LCL\n\n", fp);
+    fputs("@LCL\n", fp);
     fputs("M=D\n", fp); 
 
     // goto RET

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -59,8 +59,31 @@ void test_rfind_on_null_terminated_strings(void) {
 }
 
 void test_fileid(void) {
-    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid("path/to/myvmfile.vm"));
-    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid("myvmfile.vm"));
+    char* fileid;
+
+    fileid = get_fileid("path/to/myvmfile.vm");
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid);
+    free(fileid);
+
+    fileid = get_fileid("myvmfile.vm");
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid);
+    free(fileid);
+
+    fileid = get_fileid("myvmfile");
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid);
+    free(fileid);
+
+    fileid = get_fileid("path/to/myvmfile");
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid);
+    free(fileid);
+
+    fileid = get_fileid("path/to/myvmfile.a.b");
+    TEST_ASSERT_EQUAL_STRING("myvmfile.a", fileid);
+    free(fileid);
+
+    fileid = get_fileid(NULL);
+    TEST_ASSERT_EQUAL_STRING(NULL, fileid);
+    free(fileid);
 }
 
 int main(void)

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -58,6 +58,11 @@ void test_rfind_on_null_terminated_strings(void) {
     TEST_ASSERT_EQUAL_STRING("orld", rfind(str, 'o'));
 }
 
+void test_fileid(void) {
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid("path/to/myvmfile.vm"));
+    TEST_ASSERT_EQUAL_STRING("myvmfile", fileid("myvmfile.vm"));
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -71,6 +76,8 @@ int main(void)
     RUN_TEST(test_rfind_on_empty_strings);
     RUN_TEST(test_rfind_on_repeated_chars);
     RUN_TEST(test_rfind_on_null_terminated_strings);
+
+    RUN_TEST(test_fileid);
 
     return UNITY_END();
 }


### PR DESCRIPTION
Implement `get_fileid()` function that strips path and extension from input .vm file. For use in disambiguating static labels/symbols.