### PR TITLE
Add `-b` flag to disable automatic writing of bootstrap code

### DIFF
--- a/makefile
+++ b/makefile
@@ -93,16 +93,16 @@ ASM_TARGETS = $(join $(addsuffix /, $(VM_PROJ_DIRS)), $(addsuffix .asm, $(notdir
 translate : $(ASM_TARGETS)
 
 vm/BasicLoop/BasicLoop.asm : vm/BasicLoop/BasicLoop.vm
-	-./$(PATHB)$(OUTFILE) $@ $^
+	-./$(PATHB)$(OUTFILE) -b $@ $^
 
 vm/StaticsTest/StaticsTest.asm : vm/StaticsTest/Class1.vm vm/StaticsTest/Class2.vm vm/StaticsTest/Sys.vm
 	-./$(PATHB)$(OUTFILE) $@ $^
 
 vm/SimpleFunction/SimpleFunction.asm : vm/SimpleFunction/SimpleFunction.vm
-	-./$(PATHB)$(OUTFILE) $@ $^
+	-./$(PATHB)$(OUTFILE) -b $@ $^
 
 vm/FibonacciSeries/FibonacciSeries.asm : vm/FibonacciSeries/FibonacciSeries.vm
-	-./$(PATHB)$(OUTFILE) $@ $^
+	-./$(PATHB)$(OUTFILE) -b $@ $^
 
 vm/FibonacciElement/FibonacciElement.asm : vm/FibonacciElement/Main.vm vm/FibonacciElement/Sys.vm
 	-./$(PATHB)$(OUTFILE) $@ $^

--- a/src/lookup.h
+++ b/src/lookup.h
@@ -17,6 +17,8 @@ enum Command {
     C_FUNCTION, C_RETURN, C_CALL, C_UNKNOWN
 };
 
+enum SearchOn { VM_TOK, ASM_TOK, COM_OR_SEG };
+
 union ComOrSeg {
     enum Segment s_type;
     enum Command c_type;
@@ -29,25 +31,11 @@ struct ArgMap {
     const char*    asm_token;
 };
 
-enum SearchOn { VM_TOK, ASM_TOK, COM_OR_SEG };
-
-/*
- * commands:
- *  arithmetic: add sub neg eq gt lt and or not
- *  push
- *  pop
- *  label: 
- *  goto: goto
- *  if: if-goto
- *  function
- *  return
- *
- */
 
 struct ArgMap lookup(struct ArgMap target, struct ArgMap *source, enum SearchOn search_on);
 
-enum Command lookup_vm_command(char* token);
-enum Segment lookup_vm_segment(char* token);
-const char*  lookup_seg_type(enum Segment seg_type);
+enum Command  lookup_vm_command(char* token);
+enum Segment  lookup_vm_segment(char* token);
+const char*   lookup_seg_type(enum Segment seg_type);
 
 #endif // LOOKUP_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "utils.h"
 #include "parser.h"
 #include "writer.h"
@@ -8,32 +9,49 @@ int main(int argc, char** argv) {
 
     char* ext;
     char* expected_ext;
-    FILE *fp_out;
+    FILE* fp_out;
+
+    int   nobootstrap = 0;
+    int   option;
+
+
+    // get options
+    while ((option = getopt(argc, argv, "b")) != -1) {
+        switch (option) {
+            case 'b':
+                // if -b flag given, do not write default bootstrap assembly
+                nobootstrap = 1;
+                break;
+            default:
+                printf("Usage: ./vmtranslator [-b] <destination asm file> <source vm files>\n");
+                exit(1);
+        }
+    }
 
     // validate number of args
-    if (argc < 3) {
-        printf("Usage: ./vmtranslator <destination asm file> <source vm files>\n");
-        exit(1);
+    if (argc - optind < 2) {
+        printf("xUsage: ./vmtranslator [-b] <destination asm file> <source vm files>\n");
+        exit(2);
     }
-    
+
     // validate arg file extensions
-    for (int i=1; i<argc; ++i) {
-        expected_ext = (i == 1) ? ".asm" : ".vm";
+    for (int i=optind; i<argc; ++i) {
+        expected_ext = (i == optind) ? ".asm" : ".vm";
         ext = rfind(argv[i], '.');
         if (ext == NULL || mystrcmp(ext, expected_ext) != 0) {
             printf("Expected %s file, got: %s\n", expected_ext, argv[i]);
-            exit(2);
+            exit(3);
         }
     }
 
     // open write file
-    if (writer_init(argv[1], &fp_out) != 0) {
+    if (writer_init(argv[optind++], nobootstrap, &fp_out) != 0) {
         printf("Output file could not be created or opened for `%s`\n", argv[1]);
-        exit(3);
+        exit(4);
     }
 
     // loop through argv files and translate each
-    for (int i=2; i<argc; ++i) {
+    for (int i=optind; i<argc; ++i) {
         if (parser_translate(argv[i], fp_out) != 0) {
             // error
             break;

--- a/src/writer.c
+++ b/src/writer.c
@@ -8,7 +8,7 @@
 #define BINARY_LOAD UNARY_LOAD "D=M\n" UNARY_LOAD
 
 
-int writer_init(const char* asmfilename, FILE** fp) {
+int writer_init(const char* asmfilename, int nobootstrap, FILE** fp) {
     size_t len;
 
     printf("Write file: %s\n", asmfilename);
@@ -19,10 +19,11 @@ int writer_init(const char* asmfilename, FILE** fp) {
     }
 
     // write bootstrap
-    if (write_bootstrap(*fp) != 0) {
+    if (nobootstrap == 0 && write_bootstrap(*fp) != 0) {
         writer_close(*fp);
         return 2;
     }
+
     return 0;
 }
 

--- a/src/writer.c
+++ b/src/writer.c
@@ -7,7 +7,6 @@
 #define UNARY_LOAD  DEC "A=M\n"
 #define BINARY_LOAD UNARY_LOAD "D=M\n" UNARY_LOAD
 
-
 int writer_init(const char* asmfilename, int nobootstrap, FILE** fp) {
     size_t len;
 
@@ -183,8 +182,7 @@ int write_arithmetic(enum Command command, size_t uid, FILE* fp) {
         case C_LT:
             fputs(BINARY_LOAD, fp);
             fputs("D=D-M\n", fp);
-            //fprintf(fp, "@TRUE.%s$%s\n", ); // file id and counter
-            fprintf(fp, "@TRUE.%zu\n", uid); // file id also required if UID is reset to 0 each time parser_translate is called
+            fprintf(fp, "@TRUE.%zu\n", uid);
             switch (command) {
                 case C_EQ:
                     fputs("D;JEQ\n", fp);
@@ -200,14 +198,11 @@ int write_arithmetic(enum Command command, size_t uid, FILE* fp) {
                     break;
             }
             fputs("D=0\n", fp);
-            //fprintf(fp, "@ENDIF.%s$%s\n", ); // file id and counter
-            fprintf(fp, "@ENDIF.%zu\n", uid); // file id also required if UID is reset to 0 each time parser_translate is called
+            fprintf(fp, "@ENDIF.%zu\n", uid);
             fputs("0;JMP\n", fp);
-            //fprintf(fp, "(TRUE.%s$%s)\n", ); // file id and counter
-            fprintf(fp, "(TRUE.%zu)\n", uid); // file id also required if UID is reset to 0 each time parser_translate is called
+            fprintf(fp, "(TRUE.%zu)\n", uid);
             fputs("D=-1\n", fp);
-            //fprintf(fp, "(ENDIF.%s$%s)\n", ); // file id and counter
-            fprintf(fp, "(ENDIF.%zu)\n", uid); // file id also required if UID is reset to 0 each time parser_translate is called
+            fprintf(fp, "(ENDIF.%zu)\n", uid);
             fputs("@SP\n", fp);
             fputs("A=M\n", fp);
             fputs("M=D\n", fp);
@@ -221,7 +216,6 @@ int write_arithmetic(enum Command command, size_t uid, FILE* fp) {
 }
 
 int write_label(char* label, FILE* fp) {
-    // is this correct? Do I need to disambuguate the label, for instance with the counter?
     fprintf(fp, "(%s)\n", label);
     return 0;
 }

--- a/src/writer.h
+++ b/src/writer.h
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int writer_init(const char* asmfilename, FILE** fp);
+int writer_init(const char* asmfilename, int nobootstrap, FILE** fp);
 int writer_close(FILE* fp);
 
 int write_comment(const char* line, FILE* fp);


### PR DESCRIPTION
This PR adds functionality for a `-b` flag using `getopt` which disables automatic writing of bootstrap code. This behavior is necessary only for select test programs, which expect no bootstrap code. However, this behavior is anomalous. This feature is intended only to simplify the process of testing the translator on sample code.